### PR TITLE
better file type detection from the shebang

### DIFF
--- a/ftdetect/nftables.vim
+++ b/ftdetect/nftables.vim
@@ -1,5 +1,5 @@
 function! s:DetectFiletype()
-    if index(['#!/usr/bin/nft -f', '#!/usr/sbin/nft -f', '#!/usr/bin/env nft -f'], getline(1)) != -1
+    if getline(1) =~# '^#!.*/nft\(\s\|$\)'
         setl ft=nftables
     endif
 endfunction


### PR DESCRIPTION
The current file detection by looking at the shebang has some limitations:

* `'#!/usr/bin/nft -f'`: not sure which vendor put `nft` to a `/bin` directory
* `'#!/usr/sbin/nft -f'`: good, but would miss when used without the `-t` or the weird peoples putting a space between the `#!` and the `/`
* `'#!/usr/bin/env nft -f'`: cannot work, `env` execute a command without argument (as it is it would execute an executable named `nft\ -t`)

I propose the following regexp which would match anything containing `/nft` with or without arguments; for example:

```
#!/usr/sbin/nft -t
# ! /usr/sbin/nft
#!/usr/bin/env nft
```

Regards.